### PR TITLE
修改联合索引字段顺序，替换update_time为last_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ reasonduan/redis-manager
 [redis-manager-2.0](https://github.com/ngbdf/redis-manager/releases/download/redis-manager-2.2.0/redis-manager-2.2.0.tar.gz)
 
 # 联系方式
-> 您在使用产品的过程中如果遇到问题或者发现需要改进的地方可以通过以下两种方式直接联系我们或 Pull Request。
+> 您在使用产品的过程中如果遇到问题或者发现需要改进的地方可以通过以下方式直接联系我们或 Pull Request。
 
 Redis Manager 钉钉交流群  
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://user-gold-cdn.xitu.io/2019/11/5/16e3bca6874b2a56?w=90&h=20&f=svg&s=724)](https://travis-ci.org/ngbdf/redis-manager)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
-**Redis Manager** 是 Redis 一站式管理平台，支持集群的监控、安装、管理、告警以及基本的数据操作功能  
+**Redis Manager** 是 Redis 一站式管理平台，支持集群（cluster、master-replica、sentinel）的监控、安装（除sentinel）、管理、告警以及基本的数据操作功能
 **集群监控**：支持监控 Memory、Clients 等 Redis 重要指标；可实时查看 Redis Info、Redis Config 和 Slow Log  
 **集群创建**：支持 Docker、Machine、Humpback方式  
 **集群管理**：支持节点Forget、Replicate Of、Failover、Move Slot、Start、Stop、Restart、Delete、修改配置等功能  

--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ reasonduan/redis-manager
 
 # 联系方式
 > 您在使用产品的过程中如果遇到问题或者发现需要改进的地方可以通过以下两种方式直接联系我们或 Pull Request。
- 
-Redis Manager 微信交流群 
-
-<img src="./documents/contact/wechat.jpg" width="200px"/>
 
 Redis Manager 钉钉交流群  
 

--- a/redis-manager-dashboard/pom.xml
+++ b/redis-manager-dashboard/pom.xml
@@ -215,6 +215,11 @@
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
 
+        <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk16</artifactId>
+                <version>1.46</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/redis-manager-dashboard/src/main/java/com/newegg/ec/redis/client/RedisClusterClient.java
+++ b/redis-manager-dashboard/src/main/java/com/newegg/ec/redis/client/RedisClusterClient.java
@@ -31,7 +31,11 @@ public class RedisClusterClient implements IRedisClusterClient {
     public RedisClusterClient(RedisURI redisURI) {
         Set<HostAndPort> hostAndPortSet = redisURI.getHostAndPortSet();
         String redisPassword = redisURI.getRequirePass();
-        jedisCluster = new JedisCluster(hostAndPortSet, TIMEOUT, TIMEOUT, MAX_ATTEMPTS, redisPassword, new GenericObjectPoolConfig());
+        if (Strings.isNullOrEmpty(redisPassword)) {
+            jedisCluster = new JedisCluster(hostAndPortSet);
+        } else {
+            jedisCluster = new JedisCluster(hostAndPortSet, TIMEOUT, TIMEOUT, MAX_ATTEMPTS, redisPassword, new GenericObjectPoolConfig());
+        }
         redisClient = RedisClientFactory.buildRedisClient(redisURI);
     }
 

--- a/redis-manager-dashboard/src/main/java/com/newegg/ec/redis/dao/INodeInfoDao.java
+++ b/redis-manager-dashboard/src/main/java/com/newegg/ec/redis/dao/INodeInfoDao.java
@@ -149,7 +149,7 @@ public interface INodeInfoDao {
             "`expires` integer(8) NOT NULL, " +
             "`update_time` datetime(0) NOT NULL, " +
             "PRIMARY KEY (info_id), " +
-            "INDEX `multiple_query` (`update_time`, `time_type`, `node`) " +
+            "INDEX `multiple_query` ( `node`, `last_time`, `time_type`) " +
             ") ENGINE = InnoDB CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = Dynamic;")
     void createNodeInfoTable(@Param("clusterId") Integer clusterId);
 }

--- a/redis-manager-dashboard/src/main/java/com/newegg/ec/redis/service/impl/RdbAnalyzeResultService.java
+++ b/redis-manager-dashboard/src/main/java/com/newegg/ec/redis/service/impl/RdbAnalyzeResultService.java
@@ -38,10 +38,6 @@ public class RdbAnalyzeResultService implements IRdbAnalyzeResultService{
 	}
 	@Override
 	public void add(RDBAnalyzeResult rdbAnalyzeResult) {
-		int count = rdbAnalyzeResultMapper.selectCount();
-		if(count >= totalCount) {
-			rdbAnalyzeResultMapper.deleteOld();
-		}
 		rdbAnalyzeResultMapper.insert(rdbAnalyzeResult);
 	}
 


### PR DESCRIPTION
我们的有4个集群，平均每个集群大约有120个node，每个节点保留数据大概30万～40万行，通过mysql发现有大量的慢查询，查询语句如下：
SELECT * FROM node_info_4 WHERE last_time = 1 AND time_type = 0  AND node = '172.31.10.xxx:xxxx'
发现没有命中联合索引，因此我修改了联合索引的字段，经测试mysql的平均cpu使用从500%降到1%